### PR TITLE
Change MSEL_SVC_SESSION_SEND/RECV to MSEL_SVC_FFS_SESSION_SEND/RECV

### DIFF
--- a/software/applications/orp-bulkencryption/src/bulkencryption.c
+++ b/software/applications/orp-bulkencryption/src/bulkencryption.c
@@ -172,7 +172,7 @@ void bulkencryption_task(void *arg, const size_t arg_sz) {
 
   while (keepRunning) {
     msel_memset(pkt, 0, sizeof(*pkt));
-    msel_svc(MSEL_SVC_SESSION_RECV, pkt);
+    msel_svc(MSEL_SVC_FFS_SESSION_RECV, pkt);
 
     if (0 != pkt->session)
       processPacket(state, pkt);
@@ -258,12 +258,12 @@ void processPacket(state_t *state, ffs_packet_t *pkt) {
     msel_memset(pkt->data, 0, FFS_DATA_SIZE);
     int err_err = BulkEncryptionResponse_serialize(pkt->data, FFS_DATA_SIZE, &err_pos, BER_ERROR);
     if (!err_err) {
-      while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+      while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
         msel_svc(MSEL_SVC_YIELD, NULL);
     }
   }
   else {
-    while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+    while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
       msel_svc(MSEL_SVC_YIELD, NULL);
   }
 }

--- a/software/applications/orp-encryptor/src/encryptor.c
+++ b/software/applications/orp-encryptor/src/encryptor.c
@@ -109,7 +109,7 @@ cleanup:
 		EncryptorResponse_serialize(pkt->data, FFS_DATA_SIZE, &pos, ER_UNSUPPORTED);
     else EncryptorResponse_serialize(pkt->data, FFS_DATA_SIZE, &pos, ER_OK);
 
-    while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+    while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
         msel_svc(MSEL_SVC_YIELD, NULL);
 }
 
@@ -152,7 +152,7 @@ cleanup:
     if (err) EncryptorResponse_serialize(pkt->data, FFS_DATA_SIZE, &pos, ER_ERROR);
     else EncryptorResponse_serialize(pkt->data, FFS_DATA_SIZE, &pos, ER_OK);
 
-    while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+    while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
         msel_svc(MSEL_SVC_YIELD, NULL);
 }
 
@@ -182,7 +182,7 @@ void encryptor_task(void *arg, const size_t arg_sz) {
     while (1)
     {
         msel_memset(pkt, 0, sizeof(*pkt));
-        msel_svc(MSEL_SVC_SESSION_RECV, pkt);
+        msel_svc(MSEL_SVC_FFS_SESSION_RECV, pkt);
         if (pkt->session != 0)
         {
             switch (ctx->state)

--- a/software/applications/orp-urchat/src/urchat.c
+++ b/software/applications/orp-urchat/src/urchat.c
@@ -221,7 +221,7 @@ int chat_process_login(chat_context_t *ctx, ffs_packet_t *pkt) {
   ctx->state = CS_AWAITING_COMMANDS;
 
   /* Send the response */
-  while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+  while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
       msel_svc(MSEL_SVC_YIELD, NULL);
 
   cleanup:
@@ -255,7 +255,7 @@ int chat_process_logout(chat_context_t *ctx, ffs_packet_t *pkt, uint32_t *pos) {
   ctx->state = CS_AWAITING_LOGIN;
 
   /* Send the response */
-  while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+  while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
       msel_svc(MSEL_SVC_YIELD, NULL);
 
   cleanup:
@@ -309,7 +309,7 @@ int chat_process_setseek(chat_context_t *ctx, ffs_packet_t *pkt, uint32_t *pos) 
   msel_memset(new_seeking, 0, sizeof(new_seeking));
 
   /* Send the response */
-  while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+  while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
       msel_svc(MSEL_SVC_YIELD, NULL);
 
   cleanup:
@@ -391,7 +391,7 @@ int chat_process_getseek(chat_context_t *ctx, ffs_packet_t *pkt, uint32_t *pos) 
   }
 
   /* Send the response */
-  while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+  while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
       msel_svc(MSEL_SVC_YIELD, NULL);
 
   cleanup:
@@ -486,7 +486,7 @@ int chat_process_getchannel(chat_context_t *ctx, ffs_packet_t *pkt, uint32_t *po
   msel_memset(remote_signing_key, 0, ECC_POINT_LEN);
 
   /* Send the response */
-  while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+  while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
       msel_svc(MSEL_SVC_YIELD, NULL);
 
   cleanup:
@@ -530,7 +530,7 @@ int chat_process_closechannel(chat_context_t *ctx, ffs_packet_t *pkt, uint32_t *
   }
 
   /* Send the response */
-  while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+  while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
       msel_svc(MSEL_SVC_YIELD, NULL);
 
   cleanup:
@@ -618,7 +618,7 @@ int chat_process_getexchange(chat_context_t *ctx, ffs_packet_t *pkt, uint32_t *p
   }
 
   /* Send the response */
-  while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+  while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
       msel_svc(MSEL_SVC_YIELD, NULL);
 
 
@@ -700,7 +700,7 @@ int chat_process_encrypt(chat_context_t *ctx, ffs_packet_t *pkt, uint32_t *pos) 
   sha256_hash(ctx->sessions[channel].send_iv, SHA256_OUTPUT_LEN, ctx->sessions[channel].send_iv);
 
   /* Send the response */
-  while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+  while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
       msel_svc(MSEL_SVC_YIELD, NULL);
 
   cleanup:
@@ -917,7 +917,7 @@ int chat_process_incoming(chat_context_t *ctx, ffs_packet_t *pkt, uint32_t *pos)
     sha256_hash(ctx->sessions[channel].recv_iv, SHA256_OUTPUT_LEN, ctx->sessions[channel].recv_iv);
   }
   /* Send the response */
-  while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+  while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
       msel_svc(MSEL_SVC_YIELD, NULL);
 
   cleanup:
@@ -965,7 +965,7 @@ void chat_process_command(chat_context_t *ctx, ffs_packet_t *pkt) {
     uint32_t length = 0;
     msel_memset(pkt->data, 0, FFS_DATA_SIZE);
     if (!ChatResponse_serialize(pkt->data, FFS_DATA_SIZE, &length, CR_ERROR)) {
-      while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+      while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
           msel_svc(MSEL_SVC_YIELD, NULL);
     }
   }
@@ -999,7 +999,7 @@ void urchat_task(void *arg, const size_t arg_sz) {
 
   while (CS_SHOULD_EXIT != ctx->state) {
     msel_memset(pkt, 0, sizeof(*pkt));
-    msel_svc(MSEL_SVC_SESSION_RECV, pkt);
+    msel_svc(MSEL_SVC_FFS_SESSION_RECV, pkt);
     if (0 != pkt->session) {
       switch (ctx->state) {
         case CS_AWAITING_LOGIN:

--- a/software/applications/orp-xts-encryptor/src/xts-encryptor.c
+++ b/software/applications/orp-xts-encryptor/src/xts-encryptor.c
@@ -115,7 +115,7 @@ cleanup:
 		XtsResponse_serialize(pkt->data, FFS_DATA_SIZE, &pos, XTS_UNSUPPORTED);
     else XtsResponse_serialize(pkt->data, FFS_DATA_SIZE, &pos, XTS_OK);
 
-    while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+    while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
         msel_svc(MSEL_SVC_YIELD, NULL);
 }
 
@@ -165,7 +165,7 @@ cleanup:
 	// Now we've formed the header for the outgoing packet, so copy in the data
 	msel_memcpy(pkt->data + pos, ctx->output, ctx->block_size);
 
-    while (msel_svc(MSEL_SVC_SESSION_SEND, pkt) != MSEL_OK) 
+    while (msel_svc(MSEL_SVC_FFS_SESSION_SEND, pkt) != MSEL_OK) 
         msel_svc(MSEL_SVC_YIELD, NULL);
 }
 
@@ -195,7 +195,7 @@ void xts_encryptor_task(void *arg, const size_t arg_sz) {
     while (1)
     {
         msel_memset(pkt, 0, sizeof(*pkt));
-        msel_svc(MSEL_SVC_SESSION_RECV, pkt);
+        msel_svc(MSEL_SVC_FFS_SESSION_RECV, pkt);
         if (pkt->session != 0)
         {
             switch (ctx->state)


### PR DESCRIPTION
As pointed out by Carmelon, after sourcing devenv-settings.sh and then 'make all' , we get an error at the very end which tells MSEL_SVC_SESSION_SEND/RECV doesnt exist. Changing it to MSEL_SVC_FFS_SESSION_SEND/RECV does solve that problem.
